### PR TITLE
正規表現のキャプチャ名を修正

### DIFF
--- a/lib/ruboty/handlers/hatebu_total_count.rb
+++ b/lib/ruboty/handlers/hatebu_total_count.rb
@@ -1,7 +1,7 @@
 module Ruboty
   module Handlers
     class HatebuTotalCount < Base
-      on /count (?<url>\S+)/, description: 'count total bookmarks', name: :count
+      on /count (?<site>\S+)/, description: 'count total bookmarks', name: :count
 
       def count(message)
         Ruboty::HatebuTotalCount::Actions::Count.new(message).call

--- a/lib/ruboty/hatebu_total_count/actions/count.rb
+++ b/lib/ruboty/hatebu_total_count/actions/count.rb
@@ -16,6 +16,8 @@ module Ruboty
             message.reply(res)
           rescue XMLRPC::FaultException => e
             message.reply(e.faultString)
+          rescue => e
+            message.reply(e.message)
           end
         end
 


### PR DESCRIPTION
`Ruboty::HatebuTotalCount::Actions::Count` では `:site` という名前で参照していたので、Handlerもそれにあわせて修正しました。

また、`Ruboty::HatebuTotalCount::Actions::Count` で例外が発生した場合でもbotが死なないようにしました。
